### PR TITLE
Update tech-stack graphic & how it works copy

### DIFF
--- a/src/pages/en/getting-started.md
+++ b/src/pages/en/getting-started.md
@@ -5,16 +5,16 @@ description: Docs intro
 layout: ../../layouts/MainLayout.astro
 ---
 ***
-We've chosen a simple currency converter use–case for our sample project. It's a universally understood concept which relies on a relatively static set of entities (global currencies) along with associated values which are dynamic (real-time) in nature.
+We've chosen a simple currency converter use-case for our sample project. It's a universally understood concept which relies on a relatively static set of entities (global currencies) along with associated values which are dynamic (real-time) in nature.
 
 The first—and most important—part of realizing our sample project will be creating the `project definition` file. There are two ways we can achieve this, and typically the approach will be defined by which hat I'm wearing—developer or DevOps engineer.
 
 ### Developer
-We're going to use our code–editor of choice to create the `project definition yaml` file. We'll add the Nox library to our souce code, build our project and we'll be up & running with a simple currency microservice with all the expected CRUD endpoints.
+We're going to use our code-editor of choice to create the `project definition yaml` file. We'll add the Nox library to our souce code, build our project and we'll be up & running with a simple currency microservice with all the expected CRUD endpoints.
 
 I'm a developer, [get me outta here](./nox.lib-sample-project)
 
 ### DevOps engineer
-We're going to use the Nox.Cli tool to define our project and scaffold our entire environment, including version–control repository, project team, deployment environments, and database.
+We're going to use the Nox.Cli tool to define our project and scaffold our entire environment, including version-control repository, project team, deployment environments, and database.
 
 I like clicking ⚙️, [let's do this](./nox.cli-installation)

--- a/src/pages/en/how-it-works.md
+++ b/src/pages/en/how-it-works.md
@@ -5,22 +5,27 @@ description: Docs intro
 layout: ../../layouts/MainLayout.astro
 ---
 ***
-At its core, Nox relies on a `project definition file` which describes the attributes as well as the deployment strategy and associated tech–stack.
+At the heart of every Nox project lies a `project definition` which is typically comprised of a `service definition file` along with one (or more) `entity definition file(s)`. Together, they describe the micro-service we are building, along with the database provider (SQL Server, PostgreSQL, MySQL, etc.) and data schema used to generate the tables.
 
-This file can either be manually authored or auto–generated using the [Nox.Cli](https://github.com/NoxOrg/Nox.Cli) command–line tool. It uses YAML–syntax and a JSON schema to ensure readability and accuracy.
+Apart from the afore-mentioned, these definition files can also be used to specify project elements like messaging provider (RabbitMQ, Azure Service Bus), data sources (JSON, CSV, EXCEL, Parquet, XML), version control (Azure DevOps), and identity management (Azure AD).
+
+The `service definition file` can either be manually authored or auto-generated using the [Nox.Cli](https://github.com/NoxOrg/Nox.Cli) command-line tool. It uses YAML-syntax and a JSON schema to ensure readability and accuracy. The `entity definition file(s)` are manually defined.
 
 <div align="center">
+    <br>
     <img src="https://noxorg.dev/docs/images/nox_tech-stack.png" alt="Overview" width="100%">
+    <br>
+    <br>
 </div>
 
 ## Using the Project Definition file
 
-The Nox project is aimed at both developers and DevOps engineers, and whilst their use–cases will differ slightly, the productivity benefits are evident to both user–types.
+The Nox project is aimed at both developers and DevOps engineers, and whilst their use-cases will differ slightly, the productivity benefits are evident to both user-types.
 
-#### Developers
-From a development perspective, once the `project definition file` is placed in the project folder, and the Nox library is added to your source code the project can be built with all the relevant components being automatically scaffolded.
+### Developers
+From a development perspective, once the `project definition file(s)` are placed in the root project folder (or a dedicated 'design' sub-folder), and the Nox library is added to your source code the project can be built with all the relevant components being automatically scaffolded.
 
-#### DevOps Engineers
-From a DevOps Engineer perspective, the `project definition file` is referenced via a series of command–line instructions that can propogate environments (DEV, UAT, PROD, etc.), set up version control repositories, user groups & permissions as well as commissioning databases.
+### DevOps Engineers
+From a DevOps Engineer perspective, the `project definition file` is referenced via a series of command-line instructions that can propogate environments (DEV, UAT, PROD, etc.), set up version control repositories, user groups & permissions as well as commissioning databases.
 
 Let's [get started](./getting-started)

--- a/src/pages/en/introduction.md
+++ b/src/pages/en/introduction.md
@@ -13,7 +13,7 @@ layout: ../../layouts/MainLayout.astro
 
 ## Features
 
-Nox lets you focus on your business problem and domain, and provides you with the following auto-magic features:-
+Nox lets you focus on your business problem and domain, and provides you with the following auto-magic features:
 
 - Declaration of your core application and domain (models, data, entities, attributes and bounded contexts) in a declaritive and easily maintainable way (YAML, using YamlDotNet)
 - Automatic (and selective) Create, Read, Update and Delete (CRUD) API for entities and/or aggregate roots (supports REST with OData, with GraphQL and gRPC in the making)

--- a/src/pages/en/nox-cli-installation.md
+++ b/src/pages/en/nox-cli-installation.md
@@ -16,17 +16,17 @@ If you don't have .NET installed you can download the latest version [here](http
 
 ### Install the Nox.Cli tool
 ---
-The Nox.Cli tool is hosted on nuget.org [here](https://www.nuget.org/packages/Nox.Cli) and additional installation options are detailed there. The recommended installation method is outlined below: -
+The Nox.Cli tool is hosted on nuget.org [here](https://www.nuget.org/packages/Nox.Cli) and additional installation options are detailed there. The recommended installation method is outlined below:
 ```powershell
 dotnet tool install --global Nox.Cli
 ```
-Running the Nox.Cli tool installation with the global option yields the following output: -
+Running the Nox.Cli tool installation with the global option yields the following output:
 
 <div align="center">
     <img src="https://noxorg.dev/docs/images/nox-cli_install-clean.png" alt="Overview" width="100%">
 </div>
 
-Running Nox.Cli for the first time yields the following output: -
+Running Nox.Cli for the first time yields the following output:
 
 ```powershell
 nox
@@ -38,7 +38,7 @@ nox
     <br/>
 </div>
 
-> 💡 You may notice from the screenshot that if you are logged in to Azure it will automatically use these credentials. In the event that you're not logged into Azure you will be redirected to Microsoft login screen in a browser: -
+> 💡 You may notice from the screenshot that if you are logged in to Azure it will automatically use these credentials. In the event that you're not logged into Azure you will be redirected to Microsoft login screen in a browser:
 
 <div align="center">
     <img src="https://noxorg.dev/docs/images/windows_login-selection.png" alt="Overview">

--- a/src/pages/en/nox-cli-manifest-file.md
+++ b/src/pages/en/nox-cli-manifest-file.md
@@ -5,7 +5,7 @@ description: Docs intro
 layout: ../../layouts/MainLayout.astro
 ---
 ***
-The manifest file is tasked with propogating the enterprise–level configurations related to our project. It is hosted in a tenant–specific folder on the Nox website and would typically be maintained by the DevOps team.
+The manifest file is tasked with propogating the enterprise-level configurations related to our project. It is hosted in a tenant-specific folder on the Nox website and would typically be maintained by the DevOps team.
 
 <div align="center">
     <img src="https://noxorg.dev/docs/images/vscode_manifest-yaml.png" alt="Overview">
@@ -15,7 +15,7 @@ The manifest file is tasked with propogating the enterprise–level configuratio
 
 Firstly, the `secrets:` section is where we link to our secrets provider and vault url.
 
-The `branches:` section is where we specify the command 'categories'—for the lack of a more tech–propriate term.
+The `branches:` section is where we specify the command 'categories'—for the lack of a more tech-propriate term.
 You'll recall from running the `nox` command previously that it listed the `new`, `sync` and `version` commands as options. We'll disregard the `logout` command for now as it's baked into the tool. You will however see how these three commands have been propogated from the manifest file.
 
 <div align="center">
@@ -42,7 +42,7 @@ Similarly, in the `SyncDatabaseScript.workflow.nox.yaml` example below, we can s
     <br/>
 </div>
 
-And the output when running the `nox sync` command without any arguments reflect this: -
+And the output when running the `nox sync` command without any arguments reflect this:
 
 <div align="center">
     <img src="https://noxorg.dev/docs/images/nox-cli_sync-database-highlighted.png" alt="Overview">
@@ -50,4 +50,4 @@ And the output when running the `nox sync` command without any arguments reflect
     <br/>
 </div>
 
-Finally, the `remote-task-proxy:` section points to the url and authorisation–provide for the remote task executor which will conver in more detail later.
+Finally, the `remote-task-proxy:` section points to the url and authorisation-provide for the remote task executor which will conver in more detail later.

--- a/src/pages/en/nox-cli-sample-project.md
+++ b/src/pages/en/nox-cli-sample-project.md
@@ -9,7 +9,7 @@ The development project built for our [Nox](https://github.com/NoxOrg/Nox) sampl
 
 ### Defining the Project
 
-Running the `nox new` command outlines its usage options as seen below: -
+Running the `nox new` command outlines its usage options as seen below:
 
 ```powershell
 nox new
@@ -21,7 +21,7 @@ nox new
     <br/>
 </div>
 
-Let's create a folder for our project and run the `nox new service` command from within the newly created folder: -
+Let's create a folder for our project and run the `nox new service` command from within the newly created folder:
 
 ```powershell
 mkdir CurrencyConverter

--- a/src/pages/en/nox-lib-about.md
+++ b/src/pages/en/nox-lib-about.md
@@ -5,7 +5,7 @@ description: Docs intro
 layout: ../../layouts/MainLayout.astro
 ---
 ***
-[Nox.Lib](https://github.com/NoxOrg/Nox) is a .NET microservice framework that allows developers to rapidly build, maintain and deploy enterprise–grade, production–ready microservices. 
+[Nox.Lib](https://github.com/NoxOrg/Nox) is a .NET microservice framework that allows developers to rapidly build, maintain and deploy enterprise-grade, production-ready microservices. 
 
 It removes all the ceremony, repetition and technical details associated with building and maintaining applications without constraining developer creativity or control in any way.
 

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -69,8 +69,8 @@ h2 {
 }
 
 h1 {
-	font-size: 3.25rem;
-	font-weight: 800;
+	font-size: 2.5rem;
+	font-weight: 700;
 }
 
 h2 {


### PR DESCRIPTION
- Update nox_tech-stack graphic with Nox.Project emphasis
- Include manual-entry option on graphic for service.yaml authoring
- Substitute en-dash with hyphens on all markdown docs
- Rewrite 'how it works' copy to move emphasis from service yaml file to project definition reflecting both service and entity yamls
- 'Slimmed' down default h1 font size and weight on markdown documents