### PR TITLE
Bugfix - fix internal Astro links

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -75,7 +75,14 @@ export const SIDEBAR: Sidebar = {
 			{ text: 'Installation', link: 'en/nox-cli-installation' },
 			{ text: 'Sample Project', link: 'en/nox-cli-sample-project' },
 			{ text: 'Manifest File', link: 'en/nox-cli-manifest-file' },
+		],
+		/*
+		'Tools & Helpers': [
+			{ text: 'Nox.Cli', link: 'en/tools-nox-cli-full-page' },
+			{ text: 'Nox.Reference', link: 'en/tools-nox-reference-about' },
+			{ text: 'Nox.Types', link: 'en/tools-nox-types' }
 		]
+		*/
 	},
 };
 

--- a/src/pages/en/getting-started.md
+++ b/src/pages/en/getting-started.md
@@ -7,7 +7,7 @@ layout: ../../layouts/MainLayout.astro
 ***
 We've chosen a simple currency converter use-case for our sample project. It's a universally understood concept which relies on a relatively static set of entities (global currencies and countries) along with associated values which are dynamic (real-time) in nature.
 
-The first—and most important—part of realizing our sample project will be creating the `solution definition` file. There are two ways we can achieve this, and typically the approach will be defined by which hat I'm wearing—developer or DevOps engineer.
+The first—and most important—part of realizing our sample project will be creating the `solution definition` file. There are two ways we can achieve this, and typically the approach will be defined by which hat you're wearing—developer or DevOps engineer.
 
 ### Developer
 We're going to use our code-editor of choice to create the `solution definition yaml` file. We'll add the Nox library to our souce code, build our solution and we'll be up & running with a simple currency microservice with all the expected CRUD endpoints.

--- a/src/pages/en/getting-started.md
+++ b/src/pages/en/getting-started.md
@@ -12,9 +12,9 @@ The first—and most important—part of realizing our sample project will be cr
 ### Developer
 We're going to use our code-editor of choice to create the `solution definition yaml` file. We'll add the Nox library to our souce code, build our solution and we'll be up & running with a simple currency microservice with all the expected CRUD endpoints.
 
-I'm a developer, [get me outta here](./nox-lib-quick-start-project)
+I'm a developer, [get me outta here](nox-lib-quick-start-project)
 
 ### DevOps engineer
 We're going to use the Nox.Cli tool to define our solution and scaffold our entire environment, including version-control repository, project team, deployment environments, and database.
 
-I like clicking ⚙️, [let's do this](./nox-cli-installation)
+I like clicking ⚙️, [let's do this](nox-cli-installation)

--- a/src/pages/en/how-it-works.md
+++ b/src/pages/en/how-it-works.md
@@ -28,4 +28,4 @@ From a development perspective, once the `solution design file(s)` are placed in
 ### DevOps Engineers
 From a DevOps Engineer perspective, the `solution definition file` is referenced via a series of command-line instructions that can create environments (DEV, UAT, PROD, etc.), set up version control repositories, user groups & permissions as well as commissioning databases.
 
-Let's [get started](./getting-started)
+Let's [get started](getting-started)

--- a/src/pages/en/introduction.md
+++ b/src/pages/en/introduction.md
@@ -16,14 +16,14 @@ layout: ../../layouts/MainLayout.astro
 Nox lets you focus on your business problem and domain, and provides you with the following auto-magic features:
 
 - Declaration of your core application and domain (models, data, entities, attributes and bounded contexts) in a declaritive and easily maintainable way (YAML, using YamlDotNet)
-- Automatic (and selective) Create, Read, Update and Delete (CRUD) API for entities and/or aggregate roots (supports REST with OData, with GraphQL and gRPC in the making)
-- The choice of persisting your data in any database with current support for Sql Server, Postgress or MySql (using Entity Framework)
+- Automatic (and selective) Create, Read, Update and Delete (CRUD) API for entities and/or aggregate roots (supports REST with OData. GraphQL and gRPC support coming soon)
+- Persist your data to a number of popular database vendors including SQL Server, PostgreSQL or MySQL (using Entity Framework)
 - Automated Database Migrations (coming soon)
 - Validation of entities and attributes (using FluentValidation)
-- Logging, Observability and Monitoring (using SeriLog)
-- Events and Messaging (In process/Mediator, Azure Servicebus, Amazon SQS, RabbitMQ) using MassTransit
-- Extract-transform and load definitions from any database, file or API with bulk load and merge support
-- A task scheduler for running recurring tasks at periodic intervals (using Hangfire)
+- Logging (using SeriLog), Observability and Monitoring (using HangFire)
+- Events and Messaging (In process/Mediator, Azure Servicebus, Amazon SQS and RabbitMQ) using MassTransit
+- Extract, transform and load (ETL) definitions from any database, file or API with bulk-load and merge support
+- A task scheduler for running recurring tasks at periodic intervals (using HangFire)
 - Automated DevOps including testing and deployment
 
 ## Built With

--- a/src/pages/en/nox-cli-about.md
+++ b/src/pages/en/nox-cli-about.md
@@ -31,7 +31,7 @@ Nox.Cli is declarative in nature with the primary aim of describing a project or
 - Support secure remote task execution
 
 
-** In conjunction with the [Nox.NET](https://github.com/NoxOrg/Nox) library
+** In conjunction with the [Nox.Lib](https://github.com/NoxOrg/Nox) library
 
 ### Built With
 ---

--- a/src/pages/en/nox-cli-installation.md
+++ b/src/pages/en/nox-cli-installation.md
@@ -20,7 +20,7 @@ The Nox.Cli tool is hosted on nuget.org [here](https://www.nuget.org/packages/No
 ```powershell
 dotnet tool install --global Nox.Cli
 ```
-Running the Nox.Cli tool installation with the global option yields the following output:
+Installing the Nox.Cli tool with the global option yields the following output:
 
 <div align="center">
     <img src="https://noxorg.dev/docs/images/nox-cli_install-clean.png" alt="Overview" width="100%">

--- a/src/pages/en/nox-lib-about.md
+++ b/src/pages/en/nox-lib-about.md
@@ -18,11 +18,11 @@ It removes all the ceremony, repetition and technical details associated with bu
 Nox lets you focus on your business problem and domain, and provides you with the following auto-magic features:-
 
 - Declaration of your core application and domain (models, data, entities, attributes and bounded contexts) in a declaritive and easily maintainable way (YAML, using YamlDotNet)
-- Automatic (and selective) Create, Read, Update and Delete (CRUD) API for entities and/or aggregate roots (supports REST with OData, with GraphQL and gRPC in the making)
-- The choice of persisting your data in any database with current support for Sql Server, PostgreSQL or MySql (using Entity Framework)
+- Automatic (and selective) Create, Read, Update and Delete (CRUD) API for entities and/or aggregate roots (supports REST with OData. GraphQL and gRPC support coming soon)
+- Persist your data to a number of popular database vendors including SQL Server, PostgreSQL or MySQL (using Entity Framework)
 - Automated Database Migrations (coming soon)
 - Validation of entities and attributes (using FluentValidation)
-- Logging, Observability and Monitoring (using SeriLog)
+- Logging (using SeriLog), Observability and Monitoring (using HangFire)
 - Events and Messaging (In process/Mediator, Azure Servicebus, Amazon SQS, RabbitMQ) using MassTransit
 - Extract, transform and load (ETL) definitions from any database, file or API with bulk-load and merge support
 - A task scheduler for running recurring tasks at periodic intervals (using Hangfire)

--- a/src/pages/en/nox-lib-design-folder.md
+++ b/src/pages/en/nox-lib-design-folder.md
@@ -5,7 +5,7 @@ description: Docs intro
 layout: ../../layouts/MainLayout.astro
 ---
 ***
-Now that we're extending our project, it's a good idea to get a bit more organised. We're going to create a new folder in the root of our project to keep all the configuration files that define the design of our Nox project.
+Now that we're extending our solution, it's a good idea to get a bit more organised. We're going to create a new folder in the root of our solution to keep all the configuration files that define the design of our Nox solution.
 
 We'll call it ```./Design```, but you can call it whatever you like.
 
@@ -26,9 +26,9 @@ Next we'll update our ```appsettings.json``` file by adding a dedicated Nox sect
   }
 }
 ```
-> 💡 The Nox library is intuitive enough to scan your project folder-tree to locate project design files. Strictly speaking the step outlined above isn't required, but it's a good practice to include it for the sake of clarity.
+> 💡 The Nox library is intuitive enough to scan your project folder tree to locate solution design files. Strictly speaking the step outlined above isn't required, but it's a good practice to include it for the sake of clarity.
 
-We'll follow this by moving the ```SampleCurrency.service.nox.yaml``` file that we've previously created from the root project folder into our newly created ```./Design``` folder.
+We'll follow this by moving the ```SampleCurrency.solution.nox.yaml``` file that we've previously created from the root folder into our newly created ```./Design``` folder.
 
 We'll also create a subfolder for each of our entities. For this example we'll move the ```Currency.entity.nox.yaml``` file into a ```./Design/Currency``` subfolder.
 

--- a/src/pages/en/nox-lib-quick-start-project.md
+++ b/src/pages/en/nox-lib-quick-start-project.md
@@ -68,12 +68,12 @@ app.MapControllers();
 
 app.Run();
 ```
-### Define Your Service and Entities
+### Define Your Solution and Entities
 ---
-Create a new file to define your service called `SampleCurrency.service.nox.yaml`
+Create a new file to define your solution called `SampleCurrency.solution.nox.yaml`
 ```yaml
 #
-# SampleCurrency.service.nox.yaml
+# SampleCurrency.solution.nox.yaml
 #
 # yaml-language-server: $schema=https://noxorg.dev/schemas/NoxConfiguration.json
 #
@@ -132,9 +132,9 @@ attributes:
     type: string
     maxWidth: 5
 ```
-### Setup SqlServer with Docker
+### Setup SQL Server with Docker
 ---
-Create a `docker-compose.yaml` for running a Sql Server conatainer
+Create a `docker-compose.yaml` for running a SQL Server container
 ```yaml
 version: '3.7'
 
@@ -156,7 +156,7 @@ Then start your database with:
 ```bash
 docker-compose up -d
 ```
-### Start Your Service
+### Start your project
 ---
 Finally, start your API with:
 ```powershell

--- a/src/pages/en/nox-lib-sample-custom-controller.md
+++ b/src/pages/en/nox-lib-sample-custom-controller.md
@@ -81,7 +81,7 @@ Let's restart our project and review Swagger to see if our new controller and as
     <br>
 </div>
 
-As we can see from the graphic above, we do indeed have a new ```/GetRates``` endpoint that takes currency and optional asAt string parameters. 
+As we can see from the graphic above, we do indeed have a new ```/GetRates``` endpoint that takes currency and optional asAt (date) string parameters. 
 
 And if you wanted to see how much global inflation affected your [Apple Lobster](https://shorturl.at/rFMQV) stocking stuffer for *musuko-san* back in '21, the search might resonate.
 
@@ -89,7 +89,7 @@ And if you wanted to see how much global inflation affected your [Apple Lobster]
 
 Now would be as good a time as any to peek under the hood and see what Nox is doing in the background with our design YAML files.
 
-At compile time [Nox.Generator](https://github.com/NoxOrg/Nox.Lib/tree/main/src/Nox.Generator), which extends Microsoft's [```ISourceGenerator```](https://learn.microsoft.com/en-us/dotnet/api/microsoft.codeanalysis.isourcegenerator?view=roslyn-dotnet-4.6.0) interface, generates class definitions of all of our defined entities.
+At compile time [Nox.Generator](https://github.com/NoxOrg/Nox.Lib/tree/main/src/Nox.Generator), which extends Microsoft's [```ISourceGenerator```](https://learn.microsoft.com/en-us/dotnet/api/microsoft.codeanalysis.isourcegenerator?view=roslyn-dotnet-4.6.0) interface, generates a class definition for each of our defined entities.
 
 If you have a look under your solution dependencies you'll notice an ```Analyzers``` section which lists the generated classes under the ```Nox.Generator``` section.
 

--- a/src/pages/en/nox-lib-sample-db-migrations.md
+++ b/src/pages/en/nox-lib-sample-db-migrations.md
@@ -28,7 +28,7 @@ dotnet tool install --global dotnet-ef
 ```
 
 ### Adding Packages to our project
-We're using Sql Server for our sample project, so we'll add the relevant EF Core package to our project. If you're using an alternative database provider you can check for the appropriate directive [here](https://learn.microsoft.com/en-us/ef/core/providers/?tabs=dotnet-core-cli).
+We're using SQL Server for our sample, so we'll add the relevant EF Core package to our project. If you're using an alternative database provider you can check for the appropriate directive [here](https://learn.microsoft.com/en-us/ef/core/providers/?tabs=dotnet-core-cli).
 
 ```powershell
 dotnet add package Microsoft.EntityFrameworkCore.SqlServer
@@ -60,4 +60,4 @@ Now we'll notice that our ```SampleCurrencyDb``` database has been created and t
 
 As expected, a simple Sql ```SELECT``` statement confirms that no data currently exists.
 
-Let's turn our attention to [adding additional entities](./nox-lib-sample-entities) to our project.
+Let's turn our attention to [adding additional entities](./nox-lib-sample-entities) to our solution.

--- a/src/pages/en/nox-lib-sample-entities.md
+++ b/src/pages/en/nox-lib-sample-entities.md
@@ -5,13 +5,13 @@ description: Docs intro
 layout: ../../layouts/MainLayout.astro
 ---
 ***
-Let's add Country and Exchange Rate entities to our project next. We'll simply add new entity defintion files to our ```./Design``` folder.
+Let's add Country and Exchange Rate entities to our solution next. We'll simply add new entity defintion files to our ```./Design``` folder.
 
 ### Add Country entity
 
 Add a new ```./Design/Country``` folder and create the ```Country.entity.nox.yaml``` file.
 
-> 💡 We'll take this opportunity to add some additional country-related info fields that will prove useful for our Currency Exchange project later.
+> 💡 We'll take this opportunity to add some additional country-related info fields that will prove useful for our Currency Exchange solution later.
 
 ```yaml
 #
@@ -182,7 +182,7 @@ Let's add migrations and update the database to include our new ```Country``` an
 dotnet ef migrations add AddCountryExchangeRate --context NoxDbContext
 dotnet ef database update --context NoxDbContext
 ```
-Your project ```./Design``` folder should look like the graphic below now, and the new migrations have been added to the ```./Migrations``` folder:
+Your solution ```./Design``` folder should look like the graphic below now, and the new migrations have been added to the ```./Migrations``` folder:
 
 <div align="center">
     <img src="https://noxorg.dev/docs/images/vscode_design-folder-add-entities.png" alt="Overview" width="100%">
@@ -212,4 +212,4 @@ And if we expand the ER diagram of our ```Country``` and ```ExchangeRate``` tabl
     <br>
 </div>
 
-Next we'll move on to the exciting part, let's [source and import some data into our project](./nox-lib-sample-seed-data).
+Next we'll move on to the exciting part, let's [source and import some data into our solution](./nox-lib-sample-seed-data).

--- a/src/pages/en/nox-lib-sample-messaging.md
+++ b/src/pages/en/nox-lib-sample-messaging.md
@@ -12,7 +12,7 @@ Our system will require the ability to create and publish various system events 
 
 ### Adding message support in Nox
 
- By now you can probably guess that adding message support within our Nox project is as simple as updating our project design files. The good news is that you would be correct. We'll start by specifying our messenger(s) of choice in our service definition file.
+ By now you can probably guess that adding message support within our Nox solution is as simple as updating our solution design files. The good news is that you would be correct. We'll start by specifying our messenger(s) of choice in our solution definition file.
 
 You may have noticed in our quick-start project that we specified a messaging provider as per the code block below:
 
@@ -25,7 +25,7 @@ Again, this isn't a requirement since Nox will use this as its default under-the
 
 > 💡 MassTransit includes an implementation of the [Mediator pattern](https://en.wikipedia.org/wiki/Mediator_pattern) which runs in-process and in-memory with no transport required.
 
-We'll choose RabbitMQ for our sample project, so let's start by updating our ```./Design/SampleCurrency.service.nox.yaml``` file and substitute Mediator with RabbitMQ:
+We'll choose RabbitMQ for our sample project, so let's start by updating our ```./Design/SampleCurrency.solution.nox.yaml``` file and substitute Mediator with RabbitMQ:
 
 ```yaml
 messagingProviders:
@@ -34,7 +34,7 @@ messagingProviders:
     connectionString: rabbitmq://guest:guest@localhost/
 ```
 
-Our ```./Design/SampleCurrency.service.nox.yaml``` file should look similar to the graphic below now:
+Our ```./Design/SampleCurrency.solution.nox.yaml``` file should look similar to the graphic below now:
 
 <div align="center">
     <img src="https://noxorg.dev/docs/images/vscode_sample-messenger-define.png" alt="Overview" width="100%">
@@ -132,11 +132,11 @@ IHost host = Host.CreateDefaultBuilder(args)
 await host.RunAsync();
 ```
 
-As with our SampleCurrency project, let's create a ```./Design``` folder for our design files and start by creating ```./Design/SampleListener.service.nox.yaml``` with the code below:
+As with our SampleCurrency project, let's create a ```./Design``` folder for our design files and start by creating ```./Design/SampleListener.solution.nox.yaml``` with the code below:
 
 ```yaml
 #
-# SampleListener.service.nox.yaml
+# SampleListener.solution.nox.yaml
 #
 
 name: SampleListener
@@ -232,7 +232,9 @@ Running our SampleListener application reveals a few areas of interest. When we 
     <img src="https://noxorg.dev/docs/images/localhost_sample-rabbitmq-connections2.png" alt="Overview" width="100%">
     <br>
 </div>
+
 And in addition to the new connection, we'll notice that a ```currency-updated-event``` exchange has also been created.
+
 <div align="center">
     <img src="https://noxorg.dev/docs/images/localhost_sample-rabbitmq-exchanges2.png" alt="Overview" width="100%">
     <br>

--- a/src/pages/en/nox-lib-sample-project-overview.md
+++ b/src/pages/en/nox-lib-sample-project-overview.md
@@ -13,14 +13,14 @@ We're going to extend the simple currency service we created in the quick-start 
 </div>
 
 These are the steps we'll be undertaking:
-- Create some project order by moving our project and entity definition files into a central [design folder](./nox-lib-design-folder)
+- Create some project order by moving our solution and entity definition files into a central [design folder](./nox-lib-design-folder)
 - Take full control of our project's [database migrations](./nox-lib-sample-db-migrations) using EFCore Tools
 - Define additional country and exchange-rate [entities](./nox-lib-sample-entities) alongside our original currency entity
-- Configure our project to source [seed data](./nox-lib-sample-seed-data) from external sources for all/any of our project entities using Nox's built-in ETL module.
+- Configure our project to source [seed data](./nox-lib-sample-seed-data) from external sources for all/any of our solution entities using Nox's built-in ETL module.
 - Look at how [jobs](./nox-lib-sample-jobs) are scheduled and monitored using Hangfire
 - Add a [messenger](./nox-lib-sample-messaging) using MassTransit and set up event listeners
 
-> 💡 We're going to recreate our SampleCurrencyService project from scratch since we want to take full control of our database migrations. In our quick-start version, we had the ```autoMigrations=true``` property set in the ```SampleCurrency.service.nox.yaml``` design file. In a production environment, database migrations would typically be a more considered action.
+> 💡 We're going to recreate our SampleCurrencyService solution from scratch since we want to take full control of our database migrations. In our quick-start version, we had the ```autoMigrations=true``` property set in the ```SampleCurrency.solution.nox.yaml``` design file. In a production environment, database migrations would typically be a more considered action.
 
 ## Clean our previous project
 
@@ -39,11 +39,11 @@ Remove-Item -Recurse .\SampleCurrencyService
 
 ## Recreate our starting project
 
-Follow the [Quick-start guide](./nox-lib-quick-start-project) again up to the point before we run the project using the ```dotnet run``` command. The only change will be to set the ```autoMigrations=false``` directive in the ```SampleCurrency.service.nox.yaml``` design file as below.
+Follow the [Quick-start guide](./nox-lib-quick-start-project) again up to the point before we run the project using the ```dotnet run``` command. The only change will be to set the ```autoMigrations=false``` directive in the ```SampleCurrency.solution.nox.yaml``` design file as below.
 
 ```yaml
 #
-# SampleCurrency.service.nox.yaml
+# SampleCurrency.solution.nox.yaml
 #
 # yaml-language-server: $schema=https://noxorg.dev/schemas/NoxConfiguration.json
 #
@@ -66,4 +66,4 @@ messagingProviders:
     provider: mediator
 ```
 
-Let's take a look at the [design folder](./nox-lib-design-folder) and see how we'll be using that to organise our project.
+Let's take a look at the [design folder](./nox-lib-design-folder) and see how we'll be using that to organise our solution.

--- a/src/pages/en/nox-lib-sample-seed-data.md
+++ b/src/pages/en/nox-lib-sample-seed-data.md
@@ -19,7 +19,7 @@ Let's start by creating a ```./Data``` folder in the root folder of our project 
 
 ### Creating a Loader file
 
-We can specify data sources for our project entities by adding a ```<your service>.loader.nox.yaml``` file in their relevant folders in the ```./Design``` directory.
+We can specify data sources for our solution entities by adding a ```<your solution>.loader.nox.yaml``` file in their relevant folders in the ```./Design``` directory.
 
 <div align="center">
     <img src="https://noxorg.dev/docs/images/vscode_sample-data-and-loaders.png" alt="Overview" width="100%">
@@ -91,7 +91,7 @@ sources:
 
 ### Specifying data source properties
 
-Now that we've specifed the sources of our data for our entities, we need to tell the extract module where to find this data. We'll head back to ```./Design/SampleCurrency.service.nox.yaml``` and add a new ```dataSources``` node to our file:
+Now that we've specifed the sources of our data for our entities, we need to tell the extract module where to find this data. We'll head back to ```./Design/SampleCurrency.solution.nox.yaml``` and add a new ```dataSources``` node to our file:
 
 ```yaml
 dataSources:

--- a/src/pages/en/nox-lib-sample-seed-exchange-rates.md
+++ b/src/pages/en/nox-lib-sample-seed-exchange-rates.md
@@ -7,8 +7,8 @@ layout: ../../layouts/MainLayout.astro
 ***
 It's time to wrap up our project with a final step, arguably the actual reason we started the project. Let's take a moment to recap all the components we've added to our microservice since its humble quick-start beginnings:
 
-- We started by considering the various entities and architecture of our microservice and neatly defined that in yaml files in our design folder.
-- The Nox library scaffolded the database provider of our choice with tables and indexes based on our yaml definitions in our design file.
+- We started by considering the various entities and architecture of our microservice and neatly defined them in yaml files in our solution design folder.
+- The Nox library scaffolded the database provider of our choice with tables and indexes based on the definitions in our solution design files.
 - We seeded data for our microservice by simply specifying the source and update strategy in our entity design files.
 - We reviewed the monitoring and observability of our microservice using the Hangfire console.
 - We added an additional messenger to our microservice and added listeners to react to entity state change.
@@ -19,7 +19,7 @@ You might recall that in an earlier step of our project where we [seeded currenc
 
 > 💡 Nox supports the import of several data formats including JSON, CSV, Excel, Parquet and XML.
 
-Let's take a closer look at the individual files. Open ```exchange-rate-seeddata.csv``` in a utility of your choice. We've chosen vscode:
+Let's take a closer look at the individual files. Open ```exchange-rate-seeddata.csv``` in a utility of your choice. We've chosen [Visual Studio Code](https://code.visualstudio.com/):
 
 <div align="center">
     <img src="https://noxorg.dev/docs/images/vscode_sample-csv-data.png" alt="Overview" width="100%">
@@ -59,7 +59,7 @@ Closer inspection of these files will reveal record count and date range detail 
 | exchange-rate-seeddata.xlsx    | 40,880  | 01/01/2021 | 31/12/2021 |
 | exchange-rate-seeddata.xml     | 40,223  | 01/01/2022 | 31/12/2022 |
 
-So, in addition to our currency and country JSON data, we have exchange rate information for 2020-2023 in four different formats. All that's left is to import the data into our sample exchange rate service.
+So, in addition to our currency and country JSON data, we have exchange rate information for 2020-2022 in four different formats. All that's left is to import the data into our sample exchange rate service.
 
 ### Adding exchange rates
 
@@ -102,7 +102,7 @@ sources:
 
 We specify all relevant data sources in the ```sources``` node in our loader file.
 
-Finally we'll tell our microservice about the location of this data by adding these additional sources to the ```dataSources``` node in our ```./Design/SampleCurrency.service.nox.yaml``` file as outlined in the code snippet below. You'll recall that we already have ```JsonSeedData``` specified from earlier in our project for country and currency data.
+Finally we'll tell our microservice about the location of this data by adding these additional sources to the ```dataSources``` node in our ```./Design/SampleCurrency.solution.nox.yaml``` file as outlined in the code snippet below. You'll recall that we already have ```JsonSeedData``` specified from earlier in our project for country and currency data.
 
 ```yaml
 dataSources:

--- a/src/pages/en/tools-nox-cli-full-page.md
+++ b/src/pages/en/tools-nox-cli-full-page.md
@@ -1,0 +1,299 @@
+---
+title: Nox.Cli
+category: Tools & Helpers
+description: Docs intro
+layout: ../../layouts/MainLayout.astro
+---
+***
+Nox.Cli is a companion command-line tool that supports the core [Nox library](https://github.com/NoxOrg/Nox). Its *raison d'être* is to build upon Nox's strong efficiency focus by extending that vision to the entire Enterprise Software Roadmap. This includes fast-tracking of DevOps functions like deployment to multiple environments, setting up CI/CD pipelines and configuring resource permissions. This is achieved by integrating seamlessly with existing enterprise assets and services like Helm charts, Azure KeyVault and Active Directory.
+
+Nox.Cli is declarative in nature with the primary aim of describing a project or solution. It uses a range of plugin technologies in the development, infrastructure and DevOps realms to rapidly configure and deploy a solution in the enterprise.
+
+<div align="center">
+    <img src="https://noxorg.dev/docs/images/nox-cli_component-diagram.png" alt="Overview" width="100%">
+</div>
+
+### Main Features
+---
+
+- Accelerate and simplify the development and deployment of enterprise-grade microservices**
+- Cross-platform implementation with support for Windows, Linux and MacOS
+- Easy to install and run on developer/engineer desktop or integrate directly into DevOps pipeline
+- Workflows use YAML-syntax and is based on GitHub Actions
+- Self-documentation of project workflow to fast-track productivity of all team members that work on a project
+- Open-source plugin-based architecture allows for using/customising existing actions or developing your own
+- Users are identified based on Azure Login or other interactive authorisation service
+- Input commands (workflows) can be project-specific or organisation-centric by way of a Tenant manifest maintained by DevOps
+- Both project and Tenant KeyVaults are supported
+- Can be used both for local development environment and DevOps pipeline
+- Central management and deployment of common organisational scripts
+- Automatically updates scripts and notifies developers of version updates
+- Support secure remote task execution
+
+
+** In conjunction with the [Nox.Lib](https://github.com/NoxOrg/Nox) library
+
+### Installation
+---
+#### Prerequisites
+
+Make sure you have .NET 6.0 or later installed on your PC.
+```powershell
+dotnet --version
+```
+
+If you don't have .NET installed you can download the latest version [here](https://dotnet.microsoft.com/en-us/download).
+
+#### Install the Nox.Cli tool
+
+The Nox.Cli tool is hosted on nuget.org [here](https://www.nuget.org/packages/Nox.Cli) and additional installation options are detailed there. The recommended installation method is outlined below:
+```powershell
+dotnet tool install --global Nox.Cli
+```
+Installing the Nox.Cli tool with the global option yields the following output:
+
+<div align="center">
+    <img src="https://noxorg.dev/docs/images/nox-cli_install-clean.png" alt="Overview" width="100%">
+</div>
+
+Running Nox.Cli for the first time yields the following output:
+
+```powershell
+nox
+```
+
+<div align="center">
+    <img src="https://noxorg.dev/docs/images/nox-cli_run-check-credentials.png" alt="Overview" width="100%">
+    <br/>
+    <br/>
+</div>
+
+> 💡 You may notice from the screenshot that if you are logged in to Azure it will automatically use these credentials. In the event that you're not logged into Azure you will be redirected to Microsoft login screen in a browser:
+
+<div align="center">
+    <img src="https://noxorg.dev/docs/images/windows_login-selection.png" alt="Overview">
+    <br/>
+    <br/>
+</div>
+
+> 💡 The second important thing to note is that apart from the `--version` and `--logout` commands, the additional commands listed above are dynamically added from the workflows folder in your local repository or from a script repository which is linked to your organisation, hosted at `https://noxorg.dev/workflows/{tenant.id}/index.php`
+
+### Sample project
+---
+The development project built for our [Nox](https://github.com/NoxOrg/Nox) sample was a [simple currency microservice](https://github.com/NoxOrg/Nox#creating-a-project) with all the expected CRUD endpoints to add & maintain the currencies of our choice. We're going to use the Nox.Cli companion tool to set up the entire DevOps environment that accompanies that project.
+
+#### Defining the Project
+
+Running the `nox new` command outlines its usage options as seen below:
+
+```powershell
+nox new
+```
+
+<div align="center">
+    <img src="https://noxorg.dev/docs/images/nox-cli_new.png" alt="Overview">
+    <br/>
+    <br/>
+</div>
+
+Let's create a folder for our project and run the `nox new service` command from within the newly created folder:
+
+```powershell
+mkdir CurrencyConverter
+cd .\CurrencyConverter\
+nox new service
+```
+A series of questions follows which will determine the initial configuration of our project environment. Upon completion of the input, these options will be saved into the project configuration file called `{service.name}.service.nox.yaml`
+
+<div align="center">
+    <img src="https://noxorg.dev/docs/images/nox-cli_new-input.png" alt="Overview">
+    <br/>
+    <br/>
+</div>
+
+As you can see, the service configuration file is now present in our default project directory. Opening this file in a code editor of your choice will reveal configuration options that echoes your input from the preceding interactive step.
+
+<div align="center">
+    <img src="https://noxorg.dev/docs/images/nox_directory-service-yaml.png" alt="Overview">
+    <br/>
+    <br/>
+</div>
+
+The YAML file is registered with [schema.org](https://schema.org/) so we get linting and auto-completion to ensure accuracy and speed in configuring our service. The schema used to describe our sample project can be viewed [here](https://noxorg.dev/schemas/NoxConfiguration.json).
+
+<div align="center">
+    <img src="https://noxorg.dev/docs/images/vscode_service-yaml.png" alt="Overview">
+    <br/>
+</div>
+
+#### Commissioning the Environment
+
+Now we have defined the project attributes but all we have is a simple YAML file, but no environment as yet. Well this is where the magic really starts. We'll turn our attention to the `nox sync` command and its various options to read our project configuration file and set up the project environment as per our input.
+
+```powershell
+nox sync
+```
+
+<div align="center">
+    <img src="https://noxorg.dev/docs/images/nox-cli_sync.png" alt="Overview">
+    <br/>
+</div>
+
+#### Version Control
+
+This step will go and check the specified DevOps server and create our version control repository if not already present.
+```powershell
+nox sync version-control
+```
+<div align="center">
+    <img src="https://noxorg.dev/docs/images/nox-cli_sync-version-control.png" alt="Overview">
+    <br/>
+    <br/>
+</div>
+
+Subsequent to running this command a cursory glance at our DevOps server will reveal the newly created project.
+
+<div align="center">
+    <img src="https://noxorg.dev/docs/images/dev-azure-com_projects.png" alt="Overview">
+    <br/>
+</div>
+
+#### Azure Active Directory
+
+```powershell
+nox sync azure-active-directory
+```
+<div align="center">
+    <img src="https://noxorg.dev/docs/images/nox-cli_sync-azure-active-directory.png" alt="Overview">
+    <br/>
+    <br/>
+</div>
+
+You'll notice that your project group have now been created on Azure Active Directory.
+<div align="center">
+    <img src="https://noxorg.dev/docs/images/portal-azure-com_group-overview.png" alt="Overview">
+    <br/>
+    <br/>
+</div>
+
+If you click on the Members link of the group you'll seet that the users are as per your earlier project configuration.
+<div align="center">
+    <img src="https://noxorg.dev/docs/images/portal-azure-com_group-members.png" alt="Overview">
+    <br/>
+</div>
+
+#### Database
+
+```powershell
+nox sync database
+```
+<div align="center">
+    <img src="https://noxorg.dev/docs/images/nox-cli_sync-database.png" alt="Overview">
+    <br/>
+</div>
+
+#### Helm Chart
+
+```powershell
+nox sync helm-chart
+```
+<div align="center">
+    <img src="https://noxorg.dev/docs/images/nox-cli_sync-helm-chart.png" alt="Overview">
+    <br/>
+    <br/>
+</div>
+
+Having a look at your project on the DevOps server will reveal that the Helm Chart repo have been created.
+
+<div align="center">
+    <img src="https://noxorg.dev/docs/images/dev-azure-com_repos-helm-chart.png" alt="Overview">
+    <br/>
+    <br/>
+</div>
+
+And selecting the `App.Helmchart` repo will show the relevant files.
+
+<div align="center">
+    <img src="https://noxorg.dev/docs/images/dev-azure-com_repos-helm-chart-detail.png" alt="Overview">
+    <br/>
+</div>
+
+### Tenant Manifest
+---
+
+The manifest file is tasked with propogating the enterprise-level configurations related to our project. It is hosted in a tenant-specific folder on the Nox website and would typically be maintained by the DevOps team.
+
+<div align="center">
+    <img src="https://noxorg.dev/docs/images/vscode_manifest-yaml.png" alt="Overview">
+    <br/>
+    <br/>
+</div>
+
+Firstly, the `secrets:` section is where we link to our secrets provider and vault url.
+
+The `branches:` section is where we specify the command 'categories'—for the lack of a more tech-propriate term.
+You'll recall from running the `nox` command previously that it listed the `new`, `sync` and `version` commands as options. We'll disregard the `logout` command for now as it's baked into the tool. You will however see how these three commands have been propogated from the manifest file.
+
+<div align="center">
+    <img src="https://noxorg.dev/docs/images/vscode_new-service.png" alt="Overview">
+    <br/>
+    <br/>
+</div>
+
+Reviewing the various workflow yaml files will show how commands and their aliases are linked to the branches, outlined above. In the `NewNoxService.workflow.nox.yaml` example above, we can see how the `service` command, the `sv` alias and `|sv - Creates a new NOX app/service` description is linked to the `new` branch.
+
+Further examination of the file will also reveal the various steps performed as part of the workflow.
+
+<div align="center">
+    <img src="https://noxorg.dev/docs/images/nox-cli_new-service-highlighted.png" alt="Overview">
+    <br/>
+    <br/>
+</div>
+
+Similarly, in the `SyncDatabaseScript.workflow.nox.yaml` example below, we can see how the `database` command, the `db` alias and `|db - Ensures hosted database and roles exist for your NOX definition` description is linked to the `sync` branch.
+
+<div align="center">
+    <img src="https://noxorg.dev/docs/images/vscode_sync-database.png" alt="Overview">
+    <br/>
+    <br/>
+</div>
+
+And the output when running the `nox sync` command without any arguments reflect this:
+
+<div align="center">
+    <img src="https://noxorg.dev/docs/images/nox-cli_sync-database-highlighted.png" alt="Overview">
+    <br/>
+    <br/>
+</div>
+
+Finally, the `remote-task-proxy:` section points to the url and authorisation-provide for the remote task executor which will conver in more detail later.
+
+### Built With
+---
+[![.NET][.NET]][.NET-url]
+[![schema.org][schema.org]][schema.org-url]
+[![YamlDotNet][YamlDotNet]][YamlDotNet-url]
+
+[build-shield]: https://img.shields.io/github/actions/workflow/status/noxorg/nox.cli/nox_ci.yaml?branch=main&event=push&label=Build&style=for-the-badge
+[build-url]: https://github.com/noxorg/nox.cli/actions/workflows/nox_ci.yaml?query=branch%3Amain
+[contributors-shield]: https://img.shields.io/github/contributors/noxorg/nox.cli.svg?style=for-the-badge
+[contributors-url]: https://github.com/noxorg/nox.cli/graphs/contributors
+[forks-shield]: https://img.shields.io/github/forks/noxorg/nox.cli.svg?style=for-the-badge
+[forks-url]: https://github.com/noxorg/nox.cli/network/members
+[stars-shield]: https://img.shields.io/github/stars/noxorg/nox.cli.svg?style=for-the-badge
+[stars-url]: https://github.com/noxorg/nox.cli/stargazers
+[issues-shield]: https://img.shields.io/github/issues/noxorg/nox.cli.svg?style=for-the-badge
+[issues-url]: https://github.com/noxorg/nox.cli/issues
+[license-shield]: https://img.shields.io/github/license/noxorg/nox.cli.svg?style=for-the-badge
+[license-url]: https://github.com/noxorg/nox.cli/blob/master/LICENSE.txt
+[linkedin-shield]: https://img.shields.io/badge/-LinkedIn-black.svg?style=for-the-badge&logo=linkedin&colorB=555
+[linkedin-url]: https://ch.linkedin.com/in/sharpeandre
+[security-shield]: https://img.shields.io/sonar/vulnerabilities/NoxOrg_Nox/main?server=https%3A%2F%2Fsonarcloud.io&style=for-the-badge
+[security-url]: https://sonarcloud.io/project/security_hotspots?id=NoxOrg_Nox
+[product-screenshot]: images/goo-goo.gif
+[schema.org]: https://img.shields.io/badge/schema.org-8B0000?style=for-the-badge
+[schema.org-url]: https://www.schema.org/
+[.NET]: https://img.shields.io/badge/.NET-512BD4?style=for-the-badge&logo=dotnet&logoColor=white
+[.NET-url]: https://dotnet.microsoft.com/
+[YamlDotNet]: https://img.shields.io/badge/YamlDotNet-0769AD?style=for-the-badge
+[YamlDotNet-url]: https://github.com/aaubry/YamlDotNet

--- a/src/pages/en/tools-nox-reference-about.md
+++ b/src/pages/en/tools-nox-reference-about.md
@@ -1,0 +1,16 @@
+---
+title: About
+category: Nox.Reference
+description: Docs intro
+layout: ../../layouts/MainLayout.astro
+---
+***
+
+<div align="center">
+    <br>
+    <br>
+    <br>
+    <br>
+    <img src="https://noxorg.dev/docs/images/Logos/Nox_Under_Construction.png" alt="Overview" width="40%">
+    <p><strong>WE'RE WORKING ON THIS SECTION. PLEASE CHECK BACK SOON</strong></p>
+</div>

--- a/src/pages/en/tools-nox-types.md
+++ b/src/pages/en/tools-nox-types.md
@@ -1,0 +1,38 @@
+---
+title: Nox.Types
+category: 
+description: Docs intro
+layout: ../../layouts/MainLayout.astro
+---
+***
+
+### Introduction
+
+[Nox.Types](https://github.com/NoxOrg/Nox.Types) is a Domain driven type system for Nox solutions
+
+An important principal of Nox is that it should allow the solution to be broadly designed/specified by domain expert or business analyst rather than architects and developers.
+
+One of the key aims of Nox is that it should allow for the broad definition of the domain to be achieved by a domain expert or business analyst.
+
+It should also reduce-or ideally eliminate- the intervention by a technical resouce like an architect or developer to translate that definition before the implementation of a domain model
+
+THe YAML configuration properties of a typical solution aids in this goal, but often a further level of abstraction is required to ease this definition.
+
+Nox implements a collection of role-agnostic value objects that are language friendly and easily interpreted. universally recognised.
+
+When it comes to defining entities, Nox takes the approach of using value objects rather than primitive data types.
+
+It's useful to abstract primitive data types and persistence considerations in a domain environment where business (rather than technical) specialists can define domain entities.
+
+There is an additional mapping layer that deals with persisted to the various database primitive types.
+
+### Nox stuff
+
+<div align="center">
+    <br>
+    <br>
+    <br>
+    <br>
+    <img src="https://noxorg.dev/docs/images/Logos/Nox_Under_Construction.png" alt="Overview" width="40%">
+    <p><strong>WE'RE WORKING ON THIS SECTION. PLEASE CHECK BACK SOON</strong></p>
+</div>


### PR DESCRIPTION
Astro adds a `\` to the end of the current .md document being served which break internal links being referenced with a preceding `./` directive. Testing to see if links work if specified without `./` directive.