### PR TITLE
Updated for quick start project to align with Nox.Lib 7.1.10

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -56,10 +56,10 @@ export const SIDEBAR: Sidebar = {
 		],
 		'Nox.Lib': [
 			{ text: 'About', link: 'en/nox-lib-about' },
-			{ text: 'Quick-start Project', link: 'en/nox-lib-quick-start-project' },
+			{ text: 'Build a Nox Solution', link: 'en/nox-lib-quick-start-project' },
 			{ text: 'Exploring the API', link: 'en/nox-lib-exploring-the-api' },
 		],
-		'Sample Project': [
+		'Extending Nox': [
 			{ text: 'Overview', link: 'en/nox-lib-sample-project-overview' },
 			{ text: 'The Design Folder', link: 'en/nox-lib-design-folder' },
 			{ text: 'Database Migrations', link: 'en/nox-lib-sample-db-migrations' },

--- a/src/pages/en/nox-lib-quick-start-project.md
+++ b/src/pages/en/nox-lib-quick-start-project.md
@@ -1,10 +1,10 @@
 ---
-title: Quick-start Project
+title: Building a Nox Solution
 category: Nox.Lib
 description: Docs intro
 layout: ../../layouts/MainLayout.astro
 ---
-### Prerequisites
+### The prep work
 ---
 
 Make sure you have .NET 6 and Docker installed on your PC.
@@ -13,8 +13,6 @@ dotnet --version
 
 docker-compose --version
 ```
-### Creating a Project
----
 Create .NET 6.0 web api project at the command line in your repositories using `dotnet`
 ```powershell
 dotnet new webapi -o SampleCurrencyService
@@ -23,9 +21,111 @@ cd SampleCurrencyService
 ```
 At this point you can do a normal `dotnet run` which will present you with the standard Microsoft demo WeatherController.
 
-### Adding Nox
+### Define the solution
 ---
-Add the Nox.Lib nuget package to your project.
+
+> 💡 The ***Nox Solution*** is the central pivot around which most of Nox's domain driven design revolves. This *Solution* along with *Entities*, *Events* and *Value Objects* are the building blocks of every Nox solution.
+
+Our *Nox solution* comprises the main `[solution_name].solution.nox.yaml` file as well as one or more `[entity_name].entity.nox.yaml` entity file(s). In the interest of consistency and visibility, the Nox generator looks for these *solution design* files in a separate folder off the project root called ```./.nox/design```.
+
+We specify this design folder in our project file so that they can be included at build time. Add/modify the `<Additional files />` tag in your `[solution_name].csproj` file with the code 👇 below:
+
+```csharp
+<ItemGroup>
+  <AdditionalFiles Include=".\.nox\design\**\*.yaml" />
+</ItemGroup>
+```
+
+Create a new file in the `./.nox/design` folder to define your solution called `SampleCurrency.solution.nox.yaml`
+```yaml
+#
+# SampleCurrency.solution.nox.yaml
+#
+# yaml-language-server: $schema=https://noxorg.dev/schemas/solution.json
+#
+
+name: SampleCurrencyService
+
+description: Sample Nox solution yaml configuration
+
+domain:
+
+  entities:
+
+    - $ref: ./Currency/currency.entity.nox.yaml
+
+infrastructure:
+  
+  persistence:
+
+    databaseServer:
+      name: SampleCurrencyDb
+      provider: sqlServer
+      options: Trusted_Connection=no;connection timeout=120;TrustServerCertificate=True
+      serverUri: localhost
+      user: sa  
+      password: Developer*123
+```
+
+Next we'll define our first domain entity. Arguably, entities are the most important building blocks of any Nox solution. Let's add a *Currency* entity for our solution by creating a ```Currency.entity.nox.yaml``` file in the ```./.nox/design/Currency``` subfolder. Notice that we've created a subfolder for our *Currency* entity, and we'll follow this practice for each of our subsequent domain entities.
+
+```yaml
+#
+# Currency.entity.nox.yaml
+#
+
+name: Currency
+
+description: Currency definition and related data
+
+keys:
+
+  - name: Id
+    isRequired: true
+    description: The currency's unique identifier 
+    type: text
+    textTypeOptions:
+      isUnicode: false
+      minLength: 3
+      maxLength: 3
+
+attributes:
+
+  - name: Name
+    description: The currency's name
+    type: text
+    textTypeOptions:
+      minLength: 4
+      maxLength: 63
+    isRequired: true
+
+  - name: ISO_Alpha3
+    description: The currency's official ISO 4217 alpha-3 code
+    type: text
+    textTypeOptions:
+      isUnicode: false
+      minLength: 3
+      maxLength: 3
+    isRequired: true
+
+  - name: Symbol
+    description: The currency's well known symbol
+    type: text
+    textTypeOptions:
+      maxLength: 5
+```
+
+Our project structure should look similar to the image below now
+
+<div align="center">
+    <img src="https://noxorg.dev/docs/images/vscode_quick-start-nox-design-folder.png" alt="Overview" width="100%">
+    <br>
+    <br>
+</div>
+
+### Add the Nox library
+---
+Add the [Nox.Lib nuget](https://www.nuget.org/packages/Nox.Lib) package to your project.
 ```powershell
 dotnet add package Nox.Lib
 ```
@@ -41,16 +141,14 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddControllers();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
 
-// (2) 👇 The Nox library has Swagger built-in. Comment the line below out.
-//builder.Services.AddSwaggerGen();
-
-// (3) 👇 Add Nox to the service collection
-builder.Services.AddNox();
+// (2) 👇 Add Nox to the builder
+builder.AddNox();
 
 var app = builder.Build();
 
-// (4) 👇 Add Nox to the application middleware
+// (3) 👇 Add Nox to the application middleware
 app.UseNox();
 
 // Configure the HTTP request pipeline.
@@ -68,76 +166,17 @@ app.MapControllers();
 
 app.Run();
 ```
-### Define Your Solution and Entities
+
+### Setup SQL Server
 ---
-Create a new file to define your solution called `SampleCurrency.solution.nox.yaml`
-```yaml
-#
-# SampleCurrency.solution.nox.yaml
-#
-# yaml-language-server: $schema=https://noxorg.dev/schemas/NoxConfiguration.json
-#
 
-name: SampleCurrencyService
-
-description: Sample Currency Microservice
-
-autoMigrations: true
-
-database:
-  name: SampleCurrencyDb
-  provider: sqlServer
-  options: Trusted_Connection=no;connection timeout=120;TrustServerCertificate=True
-  server: localhost
-  user: sa  
-  password: Developer*123
-
-messagingProviders:
-  - name: InProcess
-    provider: mediator
-```
-Create an entity definition in `Currency.entity.nox.yaml`
-
-```yaml
-#
-# Currency.entity.nox.yaml
-#
-
-name: Currency
-description: Currency definition and related data
-
-attributes:
-
-  - name: Id
-    description: The currency's unique identifier 
-    isPrimaryKey: true
-    type: int
-
-  - name: Name
-    description: The currency's name 
-    isRequired: true
-    type: string
-    maxWidth: 128
-
-  - name: ISO_Alpha3
-    description: The currency's official ISO 4217 alpha-3 code
-    isRequired: true
-    isUnicode: false
-    type: char
-    minWidth: 3
-    maxWidth: 3
-
-  - name: Symbol
-    description: The currency's well known symbol
-    type: string
-    maxWidth: 5
-```
-### Setup SQL Server with Docker
----
-Create a `docker-compose.yaml` for running a SQL Server container
+Let's spin up SQL Server in a Docker container. Create a `docker-compose.yaml` for running a SQL Server container in the root folder of your project.
 ```yaml
 version: '3.7'
 
+volumes:
+  sqlserver: 
+  
 services:
   sqlserver:
     container_name: sqlserver_container
@@ -150,13 +189,69 @@ services:
       ACCEPT_EULA: "Y"
       MSSQL_PID: "Developer"
     volumes:
-      - ./.docker-data/sqlserver:/var/opt/mssql/data
+      - sqlserver:/var/opt/mssql/data
 ```
 Then start your database with:
 ```bash
 docker-compose up -d
 ```
-### Start your project
+
+### Database Migrations
+
+We'll use Microsoft's [Entity Framework Core tools](https://learn.microsoft.com/en-us/ef/core/get-started/overview/first-app?tabs=netcore-cli) to scaffold our ```SampleCurrencyDb``` database and ```Currency``` table.
+
+A glance at our Sql Server Docker instance will confirm that our ```SampleCurrencyDb``` project database has not yet been created.
+
+<div align="center">
+    <img src="https://noxorg.dev/docs/images/vscode_database-before.png" alt="Overview" width="100%">
+    <br>
+</div>
+
+#### Prerequisites
+---
+Check if you have .NET [EF Core tools](https://www.nuget.org/packages/dotnet-ef) installed.
+```powershell
+dotnet ef --version
+```
+
+If you don't, install it as per below:
+```powershell
+dotnet tool install --global dotnet-ef
+```
+
+We're using SQL Server for our sample, so we'll add the relevant EF Core package to our project. If you're using an alternative database provider you can check for the appropriate directive [here](https://learn.microsoft.com/en-us/ef/core/providers/?tabs=dotnet-core-cli).
+
+```powershell
+dotnet add package Microsoft.EntityFrameworkCore.SqlServer
+dotnet add package Microsoft.EntityFrameworkCore.Design
+```
+
+#### Add & apply migrations
+---
+```powershell
+dotnet ef migrations add InitialCreate --context SampleCurrencyServiceDbContext
+```
+Once we've run the command we'll notice a new ```./Migrations``` folder in our project containing the newly scaffolded migration files.
+
+<div align="center">
+    <img src="https://noxorg.dev/docs/images/vscode_migrations-folder.png" alt="Overview" width="100%">
+    <br>
+</div>
+
+Let's apply the migrations as per the code snipped below:
+
+```powershell
+dotnet ef database update --context SampleCurrencyServiceDbContext
+```
+Now we'll notice that our ```SampleCurrencyDb``` database has been created and that it contains a ```Currency``` table with fields as per our ```./.nox/design/Currency.entity.nox.yaml``` definition.
+
+<div align="center">
+    <img src="https://noxorg.dev/docs/images/vscode_database-after.png" alt="Overview" width="100%">
+    <br>
+</div>
+
+As expected, a simple Sql ```SELECT``` statement confirms that no data currently exists. 
+### Run the project
 ---
 Finally, start your API with:
 ```powershell


### PR DESCRIPTION
- Changed the concept of a Nox quick-start project to 'Building a Nox Solution' since we're no longer throwing away the quick start when we move onto the full sample project.
- Changed the separate (and full) Nox sample application to 'Extending Nox'.
- Moved concept around the Nox design folder and database migrations from the full sample into the initial build a Nox solution section.

Closes https://github.com/NoxOrg/Nox.Docs/issues/14